### PR TITLE
spring-boot-rest-prometheus to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,4 +21,4 @@ dependencies:
   version: 0.0.1
 - name: spring-boot-rest-prometheus
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote spring-boot-rest-prometheus to version 0.0.2